### PR TITLE
Fix for unique credential on each deployment

### DIFF
--- a/global_vars/global_dc_vars.yml
+++ b/global_vars/global_dc_vars.yml
@@ -19,7 +19,7 @@ local_users:
   arista:
     privilege: 15
     role: network-admin
-    sha512_password: "{{ ansible_password | password_hash }}"
+    sha512_password: "{{ ansible_password | password_hash(salt='workshop') }}"
 
 # AAA
 aaa_authorization:


### PR DESCRIPTION
This fix will ensure the same password hash is created on each deploy step (better use for idempotancy.